### PR TITLE
Fix identifier which has same name as statements

### DIFF
--- a/syntax/yang.vim
+++ b/syntax/yang.vim
@@ -34,14 +34,14 @@ syn match yangBadIdentifier /\c\<xml\(\h\+[A-Za-z0-9_-]\)*\>/
 " statement keywords
 syn keyword yangStatement anyxml argument augment base belongs-to bit choice
 syn keyword yangStatement config contact default description enum error-app-tag error-message
-syn keyword yangStatement extension deviation deviate feature fraction-digits grouping identity
+syn keyword yangStatement extension deviation deviate feature fraction-digits grouping
 syn keyword yangStatement import include input key leaf leaf-list length
 syn keyword yangStatement list mandatory max-elements min-elements module must namespace
 syn keyword yangStatement notification ordered-by organization output path pattern position
 syn keyword yangStatement presence range reference refine require-instance revision
-syn keyword yangStatement revision-date rpc status submodule type unique
-syn keyword yangStatement units value when yang-version yin-element 
-syn keyword yangStatement case container leaf prefix typedef uses nextgroup=yangIdentifier skipwhite
+syn keyword yangStatement revision-date status submodule type unique
+syn keyword yangStatement units value when yang-version yin-element
+syn keyword yangStatement case container identity leaf prefix typedef uses rpc nextgroup=yangIdentifier skipwhite
 
 " other keywords
 syn keyword yangOther add current delete deprecated max min not-supported

--- a/syntax/yang.vim
+++ b/syntax/yang.vim
@@ -32,15 +32,16 @@ syn match yangIdentifier /\c\<\h\+[A-Za-z0-9_-]*\>/
 syn match yangBadIdentifier /\c\<xml\(\h\+[A-Za-z0-9_-]\)*\>/
 
 " statement keywords
-syn keyword yangStatement anyxml argument augment base belongs-to bit case choice
-syn keyword yangStatement config contact container default description enum error-app-tag error-message
+syn keyword yangStatement anyxml argument augment base belongs-to bit choice
+syn keyword yangStatement config contact default description enum error-app-tag error-message
 syn keyword yangStatement extension deviation deviate feature fraction-digits grouping identity
 syn keyword yangStatement import include input key leaf leaf-list length
 syn keyword yangStatement list mandatory max-elements min-elements module must namespace
 syn keyword yangStatement notification ordered-by organization output path pattern position
-syn keyword yangStatement prefix presence range reference refine require-instance revision
-syn keyword yangStatement revision-date rpc status submodule type typedef unique
-syn keyword yangStatement units uses value when yang-version yin-element 
+syn keyword yangStatement presence range reference refine require-instance revision
+syn keyword yangStatement revision-date rpc status submodule type unique
+syn keyword yangStatement units value when yang-version yin-element 
+syn keyword yangStatement case container leaf prefix typedef uses nextgroup=yangIdentifier skipwhite
 
 " other keywords
 syn keyword yangOther add current delete deprecated max min not-supported

--- a/syntax/yang.vim
+++ b/syntax/yang.vim
@@ -35,13 +35,13 @@ syn match yangBadIdentifier /\c\<xml\(\h\+[A-Za-z0-9_-]\)*\>/
 syn keyword yangStatement argument augment base belongs-to
 syn keyword yangStatement config contact default description error-app-tag error-message
 syn keyword yangStatement extension deviation deviate fraction-digits
-syn keyword yangStatement import include input key length
+syn keyword yangStatement include input key length
 syn keyword yangStatement list mandatory max-elements min-elements module must namespace
 syn keyword yangStatement ordered-by organization output path pattern position
 syn keyword yangStatement presence range reference refine require-instance revision
 syn keyword yangStatement revision-date status submodule type
 syn keyword yangStatement units value when yang-version yin-element
-syn keyword yangStatement anyxml bit case choice container enum feature grouping identity nextgroup=yangIdentifier skipwhite
+syn keyword yangStatement anyxml bit case choice container enum feature grouping identity import nextgroup=yangIdentifier skipwhite
 syn keyword yangStatement leaf leaf-list list notification prefix rpc typedef unique uses nextgroup=yangIdentifier skipwhite
 
 " other keywords

--- a/syntax/yang.vim
+++ b/syntax/yang.vim
@@ -32,16 +32,17 @@ syn match yangIdentifier /\c\<\h\+[A-Za-z0-9_-]*\>/
 syn match yangBadIdentifier /\c\<xml\(\h\+[A-Za-z0-9_-]\)*\>/
 
 " statement keywords
-syn keyword yangStatement anyxml argument augment base belongs-to bit choice
-syn keyword yangStatement config contact default description enum error-app-tag error-message
-syn keyword yangStatement extension deviation deviate feature fraction-digits grouping
-syn keyword yangStatement import include input key leaf leaf-list length
+syn keyword yangStatement argument augment base belongs-to
+syn keyword yangStatement config contact default description error-app-tag error-message
+syn keyword yangStatement extension deviation deviate fraction-digits
+syn keyword yangStatement import include input key length
 syn keyword yangStatement list mandatory max-elements min-elements module must namespace
-syn keyword yangStatement notification ordered-by organization output path pattern position
+syn keyword yangStatement ordered-by organization output path pattern position
 syn keyword yangStatement presence range reference refine require-instance revision
-syn keyword yangStatement revision-date status submodule type unique
+syn keyword yangStatement revision-date status submodule type
 syn keyword yangStatement units value when yang-version yin-element
-syn keyword yangStatement case container identity leaf prefix typedef uses rpc nextgroup=yangIdentifier skipwhite
+syn keyword yangStatement anyxml bit case choice container enum feature grouping identity nextgroup=yangIdentifier skipwhite
+syn keyword yangStatement leaf leaf-list list notification prefix rpc typedef unique uses nextgroup=yangIdentifier skipwhite
 
 " other keywords
 syn keyword yangOther add current delete deprecated max min not-supported


### PR DESCRIPTION
This commit fix like this:

``` yang
leaf value {
     ^^^^^ here is a identifier. not a statement.
```
