### PR TITLE
Set `include` and `suffixesadd`

### DIFF
--- a/ftplugin/yang.vim
+++ b/ftplugin/yang.vim
@@ -1,0 +1,10 @@
+" Only do this when not done yet for this buffer
+if exists('b:did_ftplugin')
+    finish
+endif
+let b:did_ftplugin = 1
+
+setlocal include=^\\s*import
+setlocal suffixesadd=.yang
+
+let b:undo_ftplugin = 'setlocal include< suffixesadd<'


### PR DESCRIPTION
Educated by <https://vimways.org/2018/death-by-a-thousand-files/>, I have set the `include` and `suffixesadd` options appropriately for yang files.  Suddenly all sorts of cross-file jump-to-definition type commands start working (I mostly have in mind `[i` and its variants).

Arguably this is out of scope for this plugin, whose readme does after all explicitly say

> YANG syntax highlighting ...

No problem if so, I can just as well put this in my own local configuration.  But if you're willing to take on some modest feature creep, perhaps other people can benefit from this too.