### PR TITLE
Set simple indent options

### DIFF
--- a/indent/yang.vim
+++ b/indent/yang.vim
@@ -1,0 +1,10 @@
+" Only load this indent file when no other was loaded.
+if exists('b:did_indent')
+  finish
+endif
+let b:did_indent = 1
+
+" Not perfect, but mostly good enough...
+setlocal autoindent nocindent cinwords= smartindent
+
+let b:undo_indent = 'setlocal autoindent< cindent< cinwords< smartindent<'


### PR DESCRIPTION
Submitting #5 reminded me that I have also set up trivial indentation rules for YANG filetypes.  As in that other PR: if you are willing to have this plugin do more than only syntax highlighting, it might just as well have those too.

Feel free to reject, I'm happy to keep this stuff locally.  But it's nice to share.