### PR TITLE
ftplugin/yang.vim: Always add `-` to iskeyword

### DIFF
--- a/ftplugin/yang.vim
+++ b/ftplugin/yang.vim
@@ -14,7 +14,5 @@ silent! setlocal formatoptions+=j
 
 let b:undo_ftplugin = 'setlocal commentstring< formatoptions< include< suffixesadd<'
 
-if !has('patch-7.4.1142')
-    setlocal iskeyword+=-
-    let b:undo_ftplugin .= ' iskeyword<'
-endif
+setlocal iskeyword+=-
+let b:undo_ftplugin .= ' iskeyword<'


### PR DESCRIPTION
This makes it easy to navigate yang files using # and *

Signed-off-by: Leonard Crestez <cdleonard@gmail.com>